### PR TITLE
DEV: update to new header API

### DIFF
--- a/javascripts/discourse/api-initializers/dev-utils.js
+++ b/javascripts/discourse/api-initializers/dev-utils.js
@@ -2,7 +2,7 @@ import { apiInitializer } from "discourse/lib/api";
 import DevToolboxHeaderIcon from "../components/dev-toolbox-header-icon";
 import DevToolboxModal from "../components/modal/dev-toolbox-modal";
 
-export default apiInitializer("0.11.1", (api) => {
+export default apiInitializer("1.28.0", (api) => {
   const currentUser = api.getCurrentUser();
 
   if (!currentUser?.admin) {

--- a/javascripts/discourse/api-initializers/dev-utils.js
+++ b/javascripts/discourse/api-initializers/dev-utils.js
@@ -1,4 +1,5 @@
 import { apiInitializer } from "discourse/lib/api";
+import DevToolboxHeaderIcon from "../components/dev-toolbox-header-icon";
 import DevToolboxModal from "../components/modal/dev-toolbox-modal";
 
 export default apiInitializer("0.11.1", (api) => {
@@ -9,32 +10,18 @@ export default apiInitializer("0.11.1", (api) => {
   }
 
   if (settings.show_header_button) {
-    api.decorateWidget("header-icons:before", (helper) => {
-      return helper.attach("header-dropdown", {
-        title: themePrefix("dev_utils.toggle_btn"),
-        icon: "cog",
-        action: "toggleDevToolbox",
-      });
-    });
-
-    api.attachWidgetAction("header", "toggleDevToolbox", function () {
-      api.container.lookup("service:modal").show(DevToolboxModal);
+    api.headerIcons.add("dev-toolbox", DevToolboxHeaderIcon, {
+      before: "chat",
     });
   }
-  const isInputSelection = (el) => {
-    const inputs = ["input", "textarea", "select", "button"];
-    const elementTagName = el?.tagName.toLowerCase();
-
-    if (inputs.includes(elementTagName)) {
-      return false;
-    }
-    return true;
-  };
 
   const showDevToolbox = (event) => {
-    if (!isInputSelection(event.target)) {
+    const elementTagName = event.target?.tagName.toLowerCase();
+
+    if (["input", "textarea", "select", "button"].includes(elementTagName)) {
       return;
     }
+
     api.container.lookup("service:modal").show(DevToolboxModal);
     event.preventDefault();
     event.stopPropagation();

--- a/javascripts/discourse/components/dev-toolbox-header-icon.gjs
+++ b/javascripts/discourse/components/dev-toolbox-header-icon.gjs
@@ -1,0 +1,28 @@
+import Component from "@glimmer/component";
+import { action } from "@ember/object";
+import { service } from "@ember/service";
+import DButton from "discourse/components/d-button";
+import I18n from "I18n";
+import DevToolboxModal from "./modal/dev-toolbox-modal";
+
+export default class DevToolboxHeaderIcon extends Component {
+  @service modal;
+
+  @action
+  showModal() {
+    this.modal.show(DevToolboxModal);
+  }
+
+  get title() {
+    return I18n.t(themePrefix("dev_utils.toggle_btn"));
+  }
+
+  <template>
+    <DButton
+      @action={{this.showModal}}
+      @icon="cog"
+      @translatedTitle={{this.title}}
+      class="btn-flat icon"
+    />
+  </template>
+}


### PR DESCRIPTION
Removes widgets.
Uses new header icon API instead.

Internal ref - t/121718