### PR TITLE
DEV: Update plugin API link

### DIFF
--- a/javascripts/discourse/components/modal/dev-toolbox-modal.hbs
+++ b/javascripts/discourse/components/modal/dev-toolbox-modal.hbs
@@ -60,7 +60,7 @@
     <a
       target="_blank"
       rel="noopener noreferrer"
-      href="https://github.dev/discourse/discourse/blob/main/app/assets/javascripts/discourse/app/lib/plugin-api.js#L1"
+      href="https://github.dev/discourse/discourse/blob/main/app/assets/javascripts/discourse/app/lib/plugin-api.gjs#L1"
       class="btn btn-icon-text"
     >
       {{d-icon "code"}}


### PR DESCRIPTION
Meta: https://meta.discourse.org/t/developer-toolbox/239148/7?u=arkshine

This fixes the plugin API link.