### PR TITLE
DEV: Update deprecated Font Awesome icon names

### DIFF
--- a/.discourse-compatibility
+++ b/.discourse-compatibility
@@ -1,2 +1,3 @@
+< 3.4.0.beta2-dev: 513e441b7f918ad11e1e146f1338af6ec0a39729
 < 3.4.0.beta1-dev: c2a3c85bbc17c1041ed0e37bcd4b59aecb07aae2
 < 3.3.0.beta1-dev: 9dcf7db5dac91fcad9a653d5c68a3ba581ce7f16

--- a/javascripts/discourse/components/modal/dev-toolbox.gjs
+++ b/javascripts/discourse/components/modal/dev-toolbox.gjs
@@ -76,7 +76,7 @@ export default class DevToolboxModal extends Component {
       @title={{i18n (themePrefix "dev_utils.modal.title")}}
       class="dev-toolbox-modal"
     >
-      <h3>{{dIcon "running"}}
+      <h3>{{dIcon "person-running"}}
         {{i18n (themePrefix "dev_utils.actions.title")}}</h3>
       <div class="modal-button-group">
         <DButton
@@ -152,7 +152,7 @@ export default class DevToolboxModal extends Component {
 
       </div>
 
-      <h3>{{dIcon "tools"}}
+      <h3>{{dIcon "screwdriver-wrench"}}
         {{i18n (themePrefix "dev_utils.common_settings.title")}}</h3>
       <div class="modal-button-group">
         <ComboBox


### PR DESCRIPTION
This PR updates deprecated Font Awesome icon names. For more detail, refer to the announcement at https://meta.discourse.org/t/-/325349.