### PR TITLE
DEV: Update more deprecated Font Awesome icon names

### DIFF
--- a/about.json
+++ b/about.json
@@ -11,10 +11,10 @@
   "modifiers": {
     "svg_icons": [
       "palette",
-      "running",
+      "person-running",
       "plug",
       "exclamation",
-      "tools",
+      "screwdriver-wrench",
       "font",
       "book-open"
     ]

--- a/javascripts/discourse/components/dev-toolbox-header-icon.gjs
+++ b/javascripts/discourse/components/dev-toolbox-header-icon.gjs
@@ -20,7 +20,7 @@ export default class DevToolboxHeaderIcon extends Component {
   <template>
     <DButton
       @action={{this.showModal}}
-      @icon="cog"
+      @icon="gear"
       @translatedTitle={{this.title}}
       class="btn-flat icon dev-toolbox-trigger"
     />

--- a/javascripts/discourse/components/modal/dev-toolbox.gjs
+++ b/javascripts/discourse/components/modal/dev-toolbox.gjs
@@ -94,7 +94,7 @@ export default class DevToolboxModal extends Component {
       <h3>{{dIcon "link"}} {{i18n (themePrefix "dev_utils.links.title")}}</h3>
       <div class="modal-button-group">
         <DButton
-          @icon="paint-brush"
+          @icon="paintbrush"
           @label={{themePrefix "dev_utils.links.themes"}}
           @href="/admin/customize/themes"
         />
@@ -119,7 +119,7 @@ export default class DevToolboxModal extends Component {
           @href="/admin/plugins"
         />
         <DButton
-          @icon="user-cog"
+          @icon="user-gear"
           @label={{themePrefix "dev_utils.links.user_prefs"}}
           @href="/my/preferences/account"
         />


### PR DESCRIPTION
This PR updates more deprecated Font Awesome icon names. For more detail, refer to the announcement at https://meta.discourse.org/t/-/325349.