### PR TITLE
Changed "bottom right" to "bottom"

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -3,7 +3,7 @@ en:
     description: "A toolbox for developers to quickly toggle common actions while developing"
     settings:
       show_header_button: "Show the trigger for the dev toolbox in the header panel"
-      remove_button_from_flow: "Fixes the header button to bottom right. (Requires show_header_button to be enabled)"
+      remove_button_from_flow: "Fixes the header button to bottom. (Requires show_header_button to be enabled)"
       actions_close_modal: "Triggering an action in the toolbox will also close the toolbox modal."
   dev_utils:
     toggle_btn: "Dev Toolbox"


### PR DESCRIPTION
The arabic translator asked whether to translate "Fixes the header button to bottom right. (Requires show_header_button to be enabled)" to. "bottom left" for RTL languages. I don't think we need to worry about that in this case so I just changed "bottom right" to "bottom".