### PR TITLE
Adds link to Docs category on Meta

### DIFF
--- a/javascripts/discourse/components/modal/dev-toolbox.gjs
+++ b/javascripts/discourse/components/modal/dev-toolbox.gjs
@@ -142,6 +142,13 @@ export default class DevToolboxModal extends Component {
           @label={{themePrefix "dev_utils.links.docs"}}
           @href="https://docs.discourse.org/"
         />
+        <DButton
+          rel="noopener noreferrer"
+          target="_blank"
+          @icon="magnifying-glass"
+          @label={{themePrefix "dev_utils.links.meta"}}
+          @href="https://meta.discourse.org/c/documentation/10"
+        />
         {{#each settings.custom_links as |link|}}
           <DButton
             @icon={{link.icon}}

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -24,7 +24,8 @@ en:
       user_prefs: "User Preferences"
       text: "Text"
       plugin_api: "Plugin API"
-      docs: "Discourse Docs"
+      docs: "API Docs"
+      meta: "How-to Docs"
     common_settings:
       title: "Common Settings"
       none: "Select a setting"


### PR DESCRIPTION
Before:
<img width="586" alt="Screenshot 2025-02-07 at 3 58 16 PM" src="https://github.com/user-attachments/assets/8f3aba63-da97-45a9-946d-96d7deff78d5" />

After:
<img width="591" alt="Screenshot 2025-02-07 at 3 57 30 PM" src="https://github.com/user-attachments/assets/3b8685f6-5a29-4eca-a4b6-52b899640745" />

